### PR TITLE
[Bugfix] Update how program arguments are handled

### DIFF
--- a/.github/workflows/on-commit.yaml
+++ b/.github/workflows/on-commit.yaml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout self

--- a/.github/workflows/on-commit.yaml
+++ b/.github/workflows/on-commit.yaml
@@ -12,4 +12,6 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run tests
-        run: make test
+        run: |
+          git submodule update --init
+          make test

--- a/.github/workflows/on-commit.yaml
+++ b/.github/workflows/on-commit.yaml
@@ -1,0 +1,15 @@
+name: On Commit
+
+on:
+  push:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout self
+        uses: actions/checkout@v4
+
+      - name: Run tests
+        run: make test

--- a/.github/workflows/on-commit.yaml
+++ b/.github/workflows/on-commit.yaml
@@ -11,6 +11,11 @@ jobs:
       - name: Checkout self
         uses: actions/checkout@v4
 
+      - name: Setup Nix
+        uses: cachix/install-nix-action@v27
+        with:
+          nix_path: nixpkgs=channel:nixos-24.05
+
       - name: Run tests
         run: |
           git submodule update --init

--- a/README.md
+++ b/README.md
@@ -75,7 +75,9 @@ Let's break this down:
 * `gateway` is the command to start the executable produced by installing the
   set-get project.  That is, it is the name of the program created by running
   `go install .` in the project directory.  You can find that info in the
-  `go.mod` file.
+  `go.mod` file. Any additional arguments included in this string, 
+  separated by spaces, are assumed to be arguments to the command, e.g.
+  `"gateway --log-level=debug"`.
 
 Once this runs, all of your assets will be in the `/tmp/set-get-assets` directory.
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Let's break this down:
   `go install .` in the project directory.  You can find that info in the
   `go.mod` file. Any additional arguments included in this string, 
   separated by spaces, are assumed to be arguments to the command, e.g.
-  `"gateway --log-level=debug"`.
+  `"gateway arg1 --flag=value arg2"`.
 
 Once this runs, all of your assets will be in the `/tmp/set-get-assets` directory.
 

--- a/archive.sh
+++ b/archive.sh
@@ -112,7 +112,7 @@ function sub_package() {
 
     # Append the remaining arguments to the Nix list, quoting each one
     for arg in "$@"; do
-      cmd_list="$cmd_list, \"$arg\""
+      cmd_list="$cmd_list \"$arg\""
     done
 
     # Close the Nix list with a closing bracket

--- a/archive.sh
+++ b/archive.sh
@@ -110,11 +110,11 @@ function sub_package() {
     # list to pass to the build script. e.g.
     # "cmd arg1 --flag=value ..." --> "[ \"cmd\" \"arg1\" \"--flag=value\" ... ]"
     read -r -a cmd_array <<< "$cmd"
-    nix_cmd_list='\"[ '
+    nix_cmd_list='[ '
     for element in "${cmd_array[@]}"; do
         nix_cmd_list+='\\\"'"$element"'\\\" '
     done
-    nix_cmd_list+=']\"'
+    nix_cmd_list+=']'
 
     local tmp_dir=$(mktemp -d -t archive-package.XXXXXX)
     local staging_dir="$tmp_dir/$root_dir_name"

--- a/archive.sh
+++ b/archive.sh
@@ -126,7 +126,7 @@ function sub_package() {
     done
 
     # render the more interesting templates
-    sed -e "s|{{CMD}}|$nix_cmd_list|" ./templates/Makefile.mustache > "$staging_dir/Makefile"
+    sed -e "s/{{CMD}}/$nix_cmd_list/" ./templates/Makefile.mustache > "$staging_dir/Makefile"
 
     # copy the source code
     local ext=$(echo "${src##*.}")

--- a/archive.sh
+++ b/archive.sh
@@ -110,11 +110,11 @@ function sub_package() {
     # list to pass to the build script. e.g.
     # "cmd arg1 --flag=value ..." --> "[ \"cmd\" \"arg1\" \"--flag=value\" ... ]"
     read -r -a cmd_array <<< "$cmd"
-    nix_cmd_list="[ "
+    nix_cmd_list='\"[ '
     for element in "${cmd_array[@]}"; do
-        nix_cmd_list+="\\\"$element\\\" "
+        nix_cmd_list+='\\\"'"$element"'\\\" '
     done
-    nix_cmd_list+="]"
+    nix_cmd_list+=']\"'
 
     local tmp_dir=$(mktemp -d -t archive-package.XXXXXX)
     local staging_dir="$tmp_dir/$root_dir_name"

--- a/archive.sh
+++ b/archive.sh
@@ -104,22 +104,15 @@ function sub_package() {
     local root_dir_name=$3
     shift 3
 
-    # Now, the remaining arguments are the command and its arguments
+    # We assume that the next argument is the command to be run and any remaining
+    # arguments are arguments to that command, compiled into a Nix-syntax list,
+    # e.g. '[ "cmd" "arg1" "arg2" ... ]'
     cmd_list="[ \"$1\""
-
-    # Shift the first command argument
     shift
-
-    # Append the remaining arguments to the Nix list, quoting each one
     for arg in "$@"; do
       cmd_list="$cmd_list \"$arg\""
     done
-
-    # Close the Nix list with a closing bracket
     cmd_list="$cmd_list ]"
-
-    # Print the formatted output
-    echo "$cmd_list"
 
     local tmp_dir=$(mktemp -d -t archive-package.XXXXXX)
     local staging_dir="$tmp_dir/$root_dir_name"
@@ -130,8 +123,7 @@ function sub_package() {
         install -D "./templates/$f" "$staging_dir/$f"
     done
 
-    # Use `sed` to inject the value of `cmd_list` into the mustache template
-    # Wrap the entire list in single quotes
+    # render the more interesting templates
     sed -e "s|{{CMD}}|'$cmd_list'|" ./templates/Makefile.mustache > "$staging_dir/Makefile"
 
     # copy the source code

--- a/archive.sh
+++ b/archive.sh
@@ -95,7 +95,7 @@ function sub_package() {
         echo "    dst  Output directory. We assume it does not already exist"
         echo "    src  Source archive (created with go-proj subcommand)"
         echo "    name Name of the project"
-        echo "    cmd  Command to run the binary with arguments"
+        echo "    cmd  Command to run the binary, including arguments separated by spaces"
         exit 1
     fi
 

--- a/archive.sh
+++ b/archive.sh
@@ -108,11 +108,11 @@ function sub_package() {
     # We assume that the last argument is a string containing the command to run
     # the binary and any arguments. We need to convert this into a Nix-syntax
     # list to pass to the build script. e.g.
-    # "cmd arg1 --flag=value arg2 ..." --> [ "cmd" "arg1" "--flag=value" "arg2" ... ]
+    # "cmd arg1 --flag=value ..." --> "[ \"cmd\" \"arg1\" \"--flag=value\" ... ]"
     read -r -a cmd_array <<< "$cmd"
     nix_cmd_list="[ "
     for element in "${cmd_array[@]}"; do
-        nix_cmd_list+="\"$element\" "
+        nix_cmd_list+="\\\"$element\\\" "
     done
     nix_cmd_list+="]"
 

--- a/templates/Makefile.mustache
+++ b/templates/Makefile.mustache
@@ -1,7 +1,7 @@
 build:
 	mkdir -p output
 	nix-build docker.nix \
-		--arg cmd {{CMD}} \
+		--arg cmd "{{CMD}}" \
 		--arg src ./src.tgz \
 		--argstr imageName archive-package \
 		--argstr tagName latest \

--- a/templates/Makefile.mustache
+++ b/templates/Makefile.mustache
@@ -1,7 +1,7 @@
 build:
 	mkdir -p output
 	nix-build docker.nix \
-		--argstr cmd "{{CMD}}" \
+		--arg cmd {{CMD}} \
 		--arg src ./src.tgz \
 		--argstr imageName archive-package \
 		--argstr tagName latest \

--- a/templates/docker.nix
+++ b/templates/docker.nix
@@ -11,13 +11,12 @@ let
   };
 
   # Ensure that the cmd list is not empty and construct the cmdConfig
-  cmdConfig = if builtins.length cmd < 1 then
+  cmdConfig = if cmd == [] then
     builtins.throw "Error: The cmd list must contain at least one element."
   else
   # Prefix the executable command (first element in the cmd list) with the
   # executable path, then append the rest of the cmd list
-    [ (aPkg + "/bin/" + builtins.elemAt cmd 0) ]
-    ++ builtins.slice cmd 1 (builtins.length cmd);
+    [ (aPkg + "/bin/" + builtins.elemAt cmd 0) ] ++ builtins.tail cmd;
 
 in pkgs.dockerTools.buildImage {
   name = "${imageName}";

--- a/templates/docker.nix
+++ b/templates/docker.nix
@@ -1,23 +1,24 @@
 { cmd, src, imageName, tagName }:
 let
   nixpkgs = fetchTarball "https://github.com/NixOS/nixpkgs/tarball/nixos-24.05";
-  pkgs = import nixpkgs { config = {}; overlays = []; };
-  aPkg = import ./go.nix { pkgs = pkgs; src = src; };
-  cmdFromPkg = aPkg + "/bin/" + builtins.head cmd;
+  pkgs = import nixpkgs {
+    config = { };
+    overlays = [ ];
+  };
+  aPkg = import ./go.nix {
+    pkgs = pkgs;
+    src = src;
+  };
 
-  cmdTail = builtins.tail cmd;
-  cmdConfig = if builtins.length cmdTail > 0 then
-    [ "${cmdFromPkg}" ] ++ cmdTail
-  else
-    [ "${cmdFromPkg}" ];
+  # Prefix the executable command (first element in the cmd list) with the
+  # executable path
+  cmdConfig = [ (aPkg + "/bin/" + builtins.elemAt cmd 0) ]
+    ++ builtins.slice cmd 1 (builtins.length cmd);
 
-in
-pkgs.dockerTools.buildImage {
-    name = "${imageName}";
-    tag = "${tagName}";
-    copyToRoot = [ aPkg ];
+in pkgs.dockerTools.buildImage {
+  name = "${imageName}";
+  tag = "${tagName}";
+  copyToRoot = [ aPkg ];
 
-    config = {
-        Cmd = cmdConfig;
-    };
+  config = { Cmd = cmdConfig; };
 }

--- a/templates/docker.nix
+++ b/templates/docker.nix
@@ -10,9 +10,13 @@ let
     src = src;
   };
 
+  # Ensure that the cmd list is not empty and construct the cmdConfig
+  cmdConfig = if builtins.length cmd < 1 then
+    builtins.throw "Error: The cmd list must contain at least one element."
+  else
   # Prefix the executable command (first element in the cmd list) with the
-  # executable path
-  cmdConfig = [ (aPkg + "/bin/" + builtins.elemAt cmd 0) ]
+  # executable path, then append the rest of the cmd list
+    [ (aPkg + "/bin/" + builtins.elemAt cmd 0) ]
     ++ builtins.slice cmd 1 (builtins.length cmd);
 
 in pkgs.dockerTools.buildImage {

--- a/templates/docker.nix
+++ b/templates/docker.nix
@@ -4,11 +4,13 @@ let
   pkgs = import nixpkgs { config = {}; overlays = []; };
   aPkg = import ./go.nix { pkgs = pkgs; src = src; };
   cmdFromPkg = aPkg + "/bin/" + builtins.head cmd;
+
   cmdTail = builtins.tail cmd;
   cmdConfig = if builtins.length cmdTail > 0 then
     [ "${cmdFromPkg}" ] ++ cmdTail
   else
     [ "${cmdFromPkg}" ];
+
 in
 pkgs.dockerTools.buildImage {
     name = "${imageName}";

--- a/templates/docker.nix
+++ b/templates/docker.nix
@@ -16,7 +16,7 @@ let
   else
   # Prefix the executable command (first element in the cmd list) with the
   # executable path, then append the rest of the cmd list
-    [ (aPkg + "/bin/" + builtins.elemAt cmd 0) ] ++ builtins.tail cmd;
+    [ (aPkg + "/bin/" + builtins.head cmd) ] ++ builtins.tail cmd;
 
 in pkgs.dockerTools.buildImage {
   name = "${imageName}";

--- a/templates/docker.nix
+++ b/templates/docker.nix
@@ -3,7 +3,12 @@ let
   nixpkgs = fetchTarball "https://github.com/NixOS/nixpkgs/tarball/nixos-24.05";
   pkgs = import nixpkgs { config = {}; overlays = []; };
   aPkg = import ./go.nix { pkgs = pkgs; src = src; };
-  cmdFromPkg = aPkg + "/bin/" + cmd;
+  cmdFromPkg = aPkg + "/bin/" + builtins.head cmd;
+  cmdTail = builtins.tail cmd;
+  cmdConfig = if builtins.length cmdTail > 0 then
+    [ "${cmdFromPkg}" ] ++ cmdTail
+  else
+    [ "${cmdFromPkg}" ];
 in
 pkgs.dockerTools.buildImage {
     name = "${imageName}";
@@ -11,6 +16,6 @@ pkgs.dockerTools.buildImage {
     copyToRoot = [ aPkg ];
 
     config = {
-        Cmd = [ "${cmdFromPkg}" ];
+        Cmd = cmdConfig;
     };
 }

--- a/test/test.bats
+++ b/test/test.bats
@@ -100,7 +100,7 @@ setup() {
     # concerned with the value changing when building on different systems and
     # not the value itself. So, if we do run this test and it changes, it
     # indicates there is a problem with some build tool.
-    local want="0ede36621dee8727d23cd03a3b2c464f7e4c0d3e7c17f026db7304b94ebec30ec725436ea7fa1ebc163ac41ab05383d2"
+    local want="3071bbeafd3db708f9a29b2dc07f13c63cc591821526d3a7138a28792415d7c305d78c2d365ab086520599beb40eab1d"
 
     ./archive.sh package $BATS_TEST_TMPDIR/assets3Args ./test/test_data/go-proj-src.tgz go-proj "go-proj 1 2 3"
 
@@ -115,4 +115,3 @@ setup() {
     run jq .Measurements.PCR0 $BATS_TEST_TMPDIR/assets5Args/eif-description.json
     refute_output --partial "$want"
 }
-


### PR DESCRIPTION
_Note: I'm in unfamiliar terrain, so please advise if I am interpreting this all incorrectly!_

This PR updates archive so that you can supply arguments in a list just like you would expect to be able to when adding arguments to a docker CMD.

Problem: While the build would pass with extra arguments, the string that was assigned to the CMD line in the docker build ended up looking something like this:
Given "gateway --log-level=debug argument", the CMD would end up looking like: 
```Dockerfile
CMD [ "/bin/gateway --log-level=debug argument" ]
```
which is not correct and fails when you actually deploy the image to a nitro enclave. For multiple arguments to operate correctly in the docker image, it needs to look like: 

```Dockerfile
CMD [ "/bin/gateway",  "--log-level=debug", "argument" ]
```
This PR updates the bash script, and the nix file to this end. 

Feedback and suggestions welcome. 

Also, I think I will need some help updating the tests since I cannot run all the tests on my machine. 