### PR TITLE
[Feature] Check for empty arguments

### DIFF
--- a/archive.sh
+++ b/archive.sh
@@ -75,6 +75,11 @@ function sub_go-proj() {
 
     local go_proj_dir=$1
 
+    if [[ -z "$go_proj_dir" ]]; then
+        echo "Error: The argument <dir> cannot be empty."
+        exit 1
+    fi
+
     local proj_name=$(basename $go_proj_dir)
     local root_dir=$(dirname $go_proj_dir)
 
@@ -104,6 +109,12 @@ function sub_package() {
     local root_dir_name=$3
     shift 3
     local cmd=$@
+
+    # Check for empty string arguments
+    if [[ -z "$dst" || -z "$src" || -z "$root_dir_name" || -z "$cmd" ]]; then
+        echo "Error: None of the arguments <dst>, <src>, <name>, or <cmd> can be empty."
+        exit 1
+    fi
 
     # We assume that the last argument is a string containing the command to run
     # the binary and any arguments. We need to convert this into a Nix-syntax

--- a/test/test.bats
+++ b/test/test.bats
@@ -11,6 +11,30 @@ setup() {
     PATH="$DIR/..:$PATH"
 }
 
+@test "error path - not enough arguments archiving project" {
+    run ./archive.sh go-proj
+    assert_failure
+    assert_output --partial "Usage: $0 go-proj <dir>"
+}
+
+@test "error path - empty arguments not allowed archiving project" {
+    run ./archive.sh go-proj ''
+    assert_failure
+    assert_output --partial "Usage: $0 go-proj <dir>"
+}
+
+@test "error path - not enough arguments packaging project" {
+    run ./archive.sh package arg1 arg2 arg3
+    assert_failure
+    assert_output --partial "Usage: $0 go-proj <dir>"
+}
+
+@test "error path - empty arguments not allowed packaging project" {
+    run ./archive.sh package arg1 arg2 arg3 ''
+    assert_failure
+    assert_output --partial "Usage: $0 go-proj <dir>"
+}
+
 @test "happy path - expected hash of archive does not change" {
     # the expected hash came from running:
     #

--- a/test/test.bats
+++ b/test/test.bats
@@ -14,25 +14,21 @@ setup() {
 @test "error path - not enough arguments archiving project" {
     run ./archive.sh go-proj
     assert_failure
-    assert_output --partial "Usage: $0 go-proj <dir>"
 }
 
 @test "error path - empty arguments not allowed archiving project" {
     run ./archive.sh go-proj ''
     assert_failure
-    assert_output --partial "Usage: $0 go-proj <dir>"
 }
 
 @test "error path - not enough arguments packaging project" {
     run ./archive.sh package arg1 arg2 arg3
     assert_failure
-    assert_output --partial "Usage: $0 go-proj <dir>"
 }
 
 @test "error path - empty arguments not allowed packaging project" {
     run ./archive.sh package arg1 arg2 arg3 ''
     assert_failure
-    assert_output --partial "Usage: $0 go-proj <dir>"
 }
 
 @test "happy path - expected hash of archive does not change" {


### PR DESCRIPTION
There was a curiously subtle bug occurring in a github actions pipeline where a workflow variable was incorrect and rendered as an empty string `''`. This was counted as an argument, so it did not trigger the error case that checked for the number of arguments. This resulted in an incorrect build, but a build that still was considered a success.

This PR updates the script to check for empty arguments in the `go-proj` and `pacakge` subfunctions.

I also added some tests, but I'm not sure if they add that much. Let me know what you think!